### PR TITLE
added PATCH for /api/connections endpoint

### DIFF
--- a/__tests__/app/connections.test.ts
+++ b/__tests__/app/connections.test.ts
@@ -4,7 +4,7 @@ import db from "../../src/db/connection";
 import * as data from "../../src/db/data/test/index";
 import seed from "../../src/db/seeds/seed";
 
-beforeAll(() => seed(data));
+beforeEach(() => seed(data));
 afterAll(() => db.end());
 
 describe("/api/notAPath", () => {
@@ -36,7 +36,7 @@ describe("/api/connections", () => {
               username_1: "amaraj_93",
               username_2: "z_ali_01",
               type_of_relationship: "Friend",
-              date_of_last_contact: expect.any(String),
+              date_of_last_contact: "2025-01-01T12:45:00.000Z",
               messaging_link: "",
             });
             expect(body.createdConnection.connection_id).toEqual(expect.any(Number));
@@ -130,6 +130,98 @@ describe("/api/connections", () => {
     test("404: Responds with not found when given valid connection_id which doesn't exist", () => {
       return request(app)
         .delete("/api/connections/58")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.message).toBe("not found");
+        });
+    });
+  });
+  describe("PATCH", () => {
+    test("200: Updates type_of_relationship values of a connection object specified by connection_id, responding with updated connection, leaving other property values unchanged", () => {
+      return request(app)
+        .patch("/api/connections/1")
+        .send({
+          type_of_relationship: "Partner",
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            updatedConnection: {
+              username_1: "amaraj_93",
+              username_2: "liamc2020",
+              type_of_relationship: "Partner",
+              date_of_last_contact: "2025-04-01T12:45:00.000Z",
+              messaging_link: "",
+            },
+          })
+          expect(body.updatedConnection.connection_id).toEqual(expect.any(Number));;
+        });
+    });
+    test("200: Updates date_of_last_contact values of a connection object specified by connection_id, responding with updated connection, leaving other property values unchanged", () => {
+      return request(app)
+        .patch("/api/connections/1")
+        .send({
+          date_of_last_contact: "2025-03-12T12:45:00Z"
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            updatedConnection: {
+              username_1: "amaraj_93",
+              username_2: "liamc2020",
+              type_of_relationship: "Friend",
+              date_of_last_contact: "2025-03-12T12:45:00.000Z",
+              messaging_link: "",
+            },
+          });
+        });
+    });
+    test("200: Updates both type_of_relationship and date_of_last_contact values of a connection object specified by connection_id, responding with updated connection, leaving other property values unchanged", () => {
+      return request(app)
+        .patch("/api/connections/1")
+        .send({
+          type_of_relationship: "Family",
+          date_of_last_contact: "2025-03-12T12:45:00Z"
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body).toMatchObject({
+            updatedConnection: {
+              username_1: "amaraj_93",
+              username_2: "liamc2020",
+              type_of_relationship: "Family",
+              date_of_last_contact: "2025-03-12T12:45:00.000Z",
+              messaging_link: "",
+            },
+          });
+        });
+    });
+    test("400: Responds with bad request when request body is missing required properties", () => {
+      return request(app)
+        .patch("/api/connections/1")
+        .send({ some_other_field: "blahblah", })
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.message).toBe("bad request");
+        });
+    });
+    test("400: Responds with bad request when connection_id provided is invalid'", () => {
+      return request(app)
+        .patch("/api/connections/three")
+        .send({
+          type_of_relationship: "Partner",
+        })
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.message).toBe("bad request");
+        });
+    });
+    test("404: Responds with not found when connection_id provided is valid, but doesnt exist", () => {
+      return request(app)
+        .patch("/api/connections/58")
+        .send({
+          type_of_relationship: "Partner",
+        })
         .expect(404)
         .then(({ body }) => {
           expect(body.message).toBe("not found");

--- a/src/db/seeds/seed.ts
+++ b/src/db/seeds/seed.ts
@@ -120,7 +120,7 @@ function createConnections() {
     username_1 VARCHAR(50) NOT NULL REFERENCES users(username) ON DELETE CASCADE,
     username_2 VARCHAR(50) NOT NULL REFERENCES users(username) ON DELETE CASCADE,
     type_of_relationship VARCHAR(50), 
-    date_of_last_contact TIMESTAMP DEFAULT NULL,
+    date_of_last_contact TIMESTAMPTZ DEFAULT NULL,
     messaging_link VARCHAR(50),
     UNIQUE (username_1, username_2)
     )`);

--- a/src/dto/dtos.ts
+++ b/src/dto/dtos.ts
@@ -8,10 +8,15 @@ export interface CreateUserDto {
   password: string;
 }
 
-export type CreateConnectionDto = {
+export interface CreateConnectionDto {
   username_1: string;
   username_2: string;
   type_of_relationship?: string;
   date_of_last_contact?: string;
   messaging_link?: string;
+};
+
+export interface ChangeConnectionDto {
+  type_of_relationship?: string;
+  date_of_last_contact?: string;
 };

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -4,6 +4,7 @@ import { getUsers, postUser } from "./controllers/users.controllers";
 import {
   postConnection,
   deleteConnectionById,
+  patchConnectionById,
 } from "./controllers/connections.controllers";
 import {
   handleCustomErrors,
@@ -22,6 +23,8 @@ app.post("/api/users", postUser);
 app.post("/api/connections", postConnection);
 
 app.delete("/api/connections/:connection_id", deleteConnectionById);
+
+app.patch("/api/connections/:connection_id", patchConnectionById);
 
 app.use((request, response, next) => {
   response.status(404).send({ message: "path not found" });

--- a/src/server/controllers/connections.controllers.ts
+++ b/src/server/controllers/connections.controllers.ts
@@ -2,11 +2,10 @@ import { NextFunction, Request, Response } from "express";
 import {
   createConnection,
   removeConnectionById,
+  updateCommentById,
 } from "../models/connections.models";
 import { checkExists } from "../../utils";
-import { CreateConnectionDto } from "../../dto/dtos";
-
-type Params = { connection_id: number };
+import { ChangeConnectionDto, CreateConnectionDto } from "../../dto/dtos";
 
 export function postConnection(
   request: Request<{}, {}, CreateConnectionDto>,
@@ -24,7 +23,7 @@ export function postConnection(
 }
 
 export function deleteConnectionById(
-  request: Request<Params, {}, {}>,
+  request: Request<{connection_id: number}, {}, {}>,
   response: Response,
   next: NextFunction
 ) {
@@ -39,4 +38,25 @@ export function deleteConnectionById(
     .catch((error) => {
       next(error);
     });
+}
+
+
+export function patchConnectionById(
+  request: Request<{connection_id: number}, {}, ChangeConnectionDto>,
+  response: Response,
+  next: NextFunction
+) {
+  const { connection_id } = request.params;
+  const { type_of_relationship, date_of_last_contact } = request.body;
+
+  const promises = [updateCommentById(connection_id, type_of_relationship, date_of_last_contact)];
+  promises.push(checkExists("connections", "connection_id", connection_id));
+
+  Promise.all(promises)
+  .then(([updatedConnection]) => {
+    response.status(200).send({ updatedConnection });
+  })
+  .catch((error) => {
+    next(error);
+  });
 }


### PR DESCRIPTION
added PATCH for /api/connections endpoint which updates type_of_relationship and/or date_of_last_contact values or returns error if request body is missing required fields or connection_id is invalid or non-existent